### PR TITLE
Add support for passing NULL parameters.

### DIFF
--- a/lib/bind.ml
+++ b/lib/bind.ml
@@ -86,6 +86,14 @@ let bind b ~buffer ~size ~mysql_type ~unsigned ~at =
   setf (!@bp) T.Bind.buffer_length size;
   setf (!@bp) T.Bind.buffer buffer
 
+let null b ~at =
+  bind b
+    ~buffer:Ctypes.null
+    ~size:0
+    ~mysql_type:T.Type.null
+    ~unsigned:yes
+    ~at
+
 let tiny ?(unsigned = false) b param ~at =
   let p = allocate char (char_of_int param) in
   bind b

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -331,6 +331,7 @@ module Stmt = struct
         Array.iteri
           (fun at arg ->
             match arg with
+            | `Null -> Bind.null b ~at
             | `Int i -> Bind.int b i ~at
             | `Float x -> Bind.float b x ~at
             | `String s -> Bind.string b s ~at

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -3,7 +3,8 @@ open Ctypes
 module T = Ffi_bindings.Types(Ffi_generated_types)
 
 type value =
-  [ `Int of int
+  [ `Null
+  | `Int of int
   | `Float of float
   | `String of string
   | `Bytes of bytes

--- a/lib/mariadb.ml
+++ b/lib/mariadb.ml
@@ -24,7 +24,8 @@ module type S = sig
     type t
 
     type value =
-      [ `Int of int
+      [ `Null
+      | `Int of int
       | `Float of float
       | `String of string
       | `Bytes of bytes
@@ -32,7 +33,7 @@ module type S = sig
       ]
 
     val name : t -> string
-    val value : t -> [value | `Null]
+    val value : t -> value
     val null_value : t -> bool
     val can_be_null : t -> bool
 

--- a/lib/mariadb.mli
+++ b/lib/mariadb.mli
@@ -46,7 +46,8 @@ module type S = sig
       (** The type of fields. *)
 
     type value =
-      [ `Int of int
+      [ `Null
+      | `Int of int
       | `Float of float
       | `String of string
       | `Bytes of bytes
@@ -56,7 +57,7 @@ module type S = sig
     val name : t -> string
       (** [name field] returns the field name of [field]. *)
 
-    val value : t -> [value | `Null]
+    val value : t -> value
       (** [value field] returns the value associated with [field]. *)
 
     val null_value : t -> bool
@@ -364,7 +365,8 @@ module Nonblocking : sig
       type t
 
       type value =
-        [ `Int of int
+        [ `Null
+        | `Int of int
         | `Float of float
         | `String of string
         | `Bytes of bytes
@@ -372,7 +374,7 @@ module Nonblocking : sig
         ]
 
       val name : t -> string
-      val value : t -> [value | `Null]
+      val value : t -> value
       val null_value : t -> bool
       val can_be_null : t -> bool
 

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -344,7 +344,8 @@ module type S = sig
     type t
 
     type value =
-      [ `Int of int
+      [ `Null
+      | `Int of int
       | `Float of float
       | `String of string
       | `Bytes of bytes
@@ -352,7 +353,7 @@ module type S = sig
       ]
 
     val name : t -> string
-    val value : t -> [value | `Null]
+    val value : t -> value
     val null_value : t -> bool
     val can_be_null : t -> bool
 


### PR DESCRIPTION
I'm working on paurkedal/ocaml-caqti#2, I need a way to pass NULL parameters, since I support option types.  Mariadb has two ways to do it, with the is_null or by declaring the field to be null by type. The latter seemed natural as it only required adding `Null to the variant used for parameter passing.
