### PR TITLE
Add Stmt.reset and Stmt.free_result.

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -292,6 +292,9 @@ module Bindings (F : Cstubs.FOREIGN) = struct
   let mysql_stmt_prepare = foreign "mysql_stmt_prepare"
     (stmt @-> ptr char @-> ulong @-> returning int)
 
+  let mysql_stmt_reset = foreign "mysql_stmt_reset"
+    (stmt @-> returning my_bool)
+
   let mysql_stmt_execute = foreign "mysql_stmt_execute"
     (stmt @-> returning int)
 
@@ -386,6 +389,12 @@ module Bindings (F : Cstubs.FOREIGN) = struct
 
   let mysql_stmt_prepare_cont = foreign "mysql_stmt_prepare_cont"
     (ptr int @-> stmt @-> int @-> returning int)
+
+  let mysql_stmt_reset_start = foreign "mysql_stmt_reset_start"
+    (ptr my_bool @-> stmt @-> returning int)
+
+  let mysql_stmt_reset_cont = foreign "mysql_stmt_reset_cont"
+    (ptr my_bool @-> stmt @-> int @-> returning int)
 
   let mysql_stmt_execute_start = foreign "mysql_stmt_execute_start"
     (ptr int @-> stmt @-> returning int)

--- a/lib/binding_wrappers.ml
+++ b/lib/binding_wrappers.ml
@@ -108,6 +108,9 @@ let mysql_stmt_prepare stmt query =
   let query = char_ptr_buffer_of_string query in
   B.mysql_stmt_prepare stmt query len = 0
 
+let mysql_stmt_reset stmt =
+  B.mysql_stmt_reset stmt = '\000'
+
 let mysql_stmt_execute stmt =
   B.mysql_stmt_execute stmt = 0
 
@@ -193,6 +196,12 @@ let mysql_stmt_prepare_start stmt query =
 
 let mysql_stmt_prepare_cont stmt status =
   handle_int (fun err -> B.mysql_stmt_prepare_cont err stmt status)
+
+let mysql_stmt_reset_start stmt =
+  handle_char (fun err -> B.mysql_stmt_reset_start err stmt)
+
+let mysql_stmt_reset_cont stmt status =
+  handle_char (fun err -> B.mysql_stmt_reset_cont err stmt status)
 
 let mysql_stmt_execute_start stmt =
   handle_int (fun err -> B.mysql_stmt_execute_start err stmt)

--- a/lib/blocking.ml
+++ b/lib/blocking.ml
@@ -162,6 +162,13 @@ module Stmt = struct
       | `Error e -> Error e
     end
 
+  let reset stmt =
+    let raw = stmt.Common.Stmt.raw in
+    if B.mysql_stmt_free_result raw && B.mysql_stmt_reset raw then
+      Ok ()
+    else
+      Error (Common.Stmt.error stmt)
+
   let close stmt =
     let raw = stmt.Common.Stmt.raw in
     if B.mysql_stmt_free_result raw && B.mysql_stmt_close raw then

--- a/lib/mariadb.ml
+++ b/lib/mariadb.ml
@@ -75,6 +75,7 @@ module type S = sig
     type t
 
     val execute : t -> Field.value array -> Res.t option result
+    val reset : t -> unit result
     val close : t -> unit result
   end
 

--- a/lib/mariadb.mli
+++ b/lib/mariadb.mli
@@ -146,6 +146,11 @@ module type S = sig
           binding to it the query parameters [params] and returns a [Res.t],
           the query result. *)
 
+    val reset : t -> unit result
+      (** [reset stmt] reset the client and server state of [stmt] to what they
+          were after [stmt] was prepared, and frees up any {!Res.t} produced by
+          [stmt]. *)
+
     val close : t -> unit result
 			(** [close stmt] closes the prepapred statement [stmt] and frees
 					any allocated memory associated with it and its result. *)
@@ -403,6 +408,7 @@ module Nonblocking : sig
       type t
 
       val execute : t -> Field.value array -> Res.t option result future
+      val reset : t -> unit result future
       val close : t -> unit result future
     end
 

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -284,6 +284,21 @@ module Stmt = struct
   let close stmt =
     (close_start stmt, close_cont stmt)
 
+  let handle_reset stmt f =
+    match f stmt.Common.Stmt.raw with
+    | 0, '\000' -> `Ok ()
+    | 0, _ -> `Error (Common.Stmt.error stmt)
+    | s, _ -> `Wait (Status.of_int s)
+
+  let reset_start stmt () =
+    handle_reset stmt B.mysql_stmt_reset_start
+
+  let reset_cont stmt status =
+    handle_reset stmt ((flip B.mysql_stmt_reset_cont) status)
+
+  let reset mariadb =
+    (reset_start mariadb, reset_cont mariadb)
+
   let handle_next stmt f =
     match f stmt.Common.Stmt.raw with
     | 0, 0 -> `Ok true
@@ -386,6 +401,7 @@ module type S = sig
     type t
 
     val execute : t -> Field.value array -> Res.t option result future
+    val reset : t -> unit result future
     val close : t -> unit result future
   end
 
@@ -589,6 +605,12 @@ module Make (W : Wait) : S with type 'a future = 'a W.IO.future = struct
       let start () = handle_free B.mysql_stmt_free_result_start in
       let cont s = handle_free ((flip B.mysql_stmt_free_result_cont) s) in
       nonblocking stmt.Common.Stmt.mariadb (start, cont)
+
+    let reset stmt =
+      free_res stmt
+      >>= function
+      | Ok () -> nonblocking stmt.Common.Stmt.mariadb (Stmt.reset stmt)
+      | Error _ as e -> return e
 
     let close stmt =
       free_res stmt


### PR DESCRIPTION
It seems both `reset` and `free_result` should be called if caching statements for later use.
