### PR TITLE
ocamlbuild is a build dependency

### DIFF
--- a/opam
+++ b/opam
@@ -18,6 +18,7 @@ remove: [
 ]
 depends: [
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}
   "ctypes-foreign" {>= "0.4.0"}
 ]


### PR DESCRIPTION
opam's CI complains about it: https://ci.ocamllabs.io/log/saved/docker-run-d04bdcb675a070f0c73f7d0ad6c77369/6faf245e6cf90fc58e48b93f0edbf5fd6acece0b