### PR TITLE
Support microsecond precision for time stamps.

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -155,6 +155,7 @@ module Types (F: Cstubs.Types.TYPE) = struct
     let hour = field t "hour" uint
     let minute = field t "minute" uint
     let second = field t "second" uint
+    let second_part = field t "second_part" ulong
 
     let () = seal t
   end

--- a/lib/bind.ml
+++ b/lib/bind.ml
@@ -173,12 +173,14 @@ let type_of_time_kind = function
 let time b param ~at =
   let tp = allocate_n T.Time.t ~count:1 in
   let to_uint = Unsigned.UInt.of_int in
+  let to_ulong = Unsigned.ULong.of_int in
   setf (!@tp) T.Time.year (to_uint param.Time.year);
   setf (!@tp) T.Time.month (to_uint param.Time.month);
   setf (!@tp) T.Time.day (to_uint param.Time.day);
   setf (!@tp) T.Time.hour (to_uint param.Time.hour);
   setf (!@tp) T.Time.minute (to_uint param.Time.minute);
   setf (!@tp) T.Time.second (to_uint param.Time.second);
+  setf (!@tp) T.Time.second_part (to_ulong param.Time.microsecond);
   bind b
     ~buffer:(coerce (ptr T.Time.t) (ptr void) tp)
     ~size:(sizeof T.Time.t)

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -53,6 +53,7 @@ let to_time field kind =
   let buf = buffer field in
   let tp = coerce (ptr void) (ptr T.Time.t) buf in
   let member f = Unsigned.UInt.to_int @@ getf (!@tp) f in
+  let member_long f = Unsigned.ULong.to_int @@ getf (!@tp) f in
   { Time.
     year   = member T.Time.year
   ; month  = member T.Time.month
@@ -60,6 +61,7 @@ let to_time field kind =
   ; hour   = member T.Time.hour
   ; minute = member T.Time.minute
   ; second = member T.Time.second
+  ; microsecond = member_long T.Time.second_part
   ; kind
   }
 

--- a/lib/mariadb.ml
+++ b/lib/mariadb.ml
@@ -11,13 +11,14 @@ module type S = sig
     val hour : t -> int
     val minute : t -> int
     val second : t -> int
+    val microsecond : t -> int
 
-    val time : hour:int -> minute:int -> second:int -> t
+    val time : hour:int -> minute:int -> ?microsecond:int -> second:int -> t
     val local_timestamp : float -> t
     val utc_timestamp : float -> t
     val date : year:int -> month:int -> day:int -> t
     val datetime : year:int -> month:int -> day:int
-                -> hour:int -> minute:int -> second:int -> t
+                -> hour:int -> minute:int -> ?microsecond:int -> second:int -> t
   end
 
   module Field : sig

--- a/lib/mariadb.mli
+++ b/lib/mariadb.mli
@@ -29,15 +29,16 @@ module type S = sig
     val hour : t -> int
     val minute : t -> int
     val second : t -> int
+    val microsecond : t -> int
 
     (** {2 Creation of time values} *)
 
-    val time : hour:int -> minute:int -> second:int -> t
+    val time : hour:int -> minute:int -> ?microsecond:int -> second:int -> t
     val local_timestamp : float -> t
     val utc_timestamp : float -> t
     val date : year:int -> month:int -> day:int -> t
     val datetime : year:int -> month:int -> day:int
-                -> hour:int -> minute:int -> second:int -> t
+                -> hour:int -> minute:int -> ?microsecond:int -> second:int -> t
   end
 
   (** This module defines a database field retrieved by a query. *)
@@ -356,13 +357,14 @@ module Nonblocking : sig
       val hour : t -> int
       val minute : t -> int
       val second : t -> int
+      val microsecond : t -> int
 
-      val time : hour:int -> minute:int -> second:int -> t
+      val time : hour:int -> minute:int -> ?microsecond:int -> second:int -> t
       val local_timestamp : float -> t
       val utc_timestamp : float -> t
       val date : year:int -> month:int -> day:int -> t
       val datetime : year:int -> month:int -> day:int
-                  -> hour:int -> minute:int -> second:int -> t
+                  -> hour:int -> minute:int -> ?microsecond:int -> second:int -> t
     end
 
     module Field : sig

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -370,13 +370,14 @@ module type S = sig
     val hour : t -> int
     val minute : t -> int
     val second : t -> int
+    val microsecond : t -> int
 
-    val time : hour:int -> minute:int -> second:int -> t
+    val time : hour:int -> minute:int -> ?microsecond:int -> second:int -> t
     val local_timestamp : float -> t
     val utc_timestamp : float -> t
     val date : year:int -> month:int -> day:int -> t
     val datetime : year:int -> month:int -> day:int
-                -> hour:int -> minute:int -> second:int -> t
+                -> hour:int -> minute:int -> ?microsecond:int -> second:int -> t
   end
 
   module Field : sig

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -7,6 +7,7 @@ type t =
   ; hour : int
   ; minute : int
   ; second : int
+  ; microsecond : int
   ; kind : kind
   }
 
@@ -16,25 +17,29 @@ let day t = t.day
 let hour t = t.hour
 let minute t = t.minute
 let second t = t.second
+let microsecond t = t.microsecond
 
-let time ~hour ~minute ~second =
+let time ~hour ~minute ?(microsecond = 0) ~second =
   { year = 0
   ; month = 0
   ; day = 0
   ; hour
   ; minute
   ; second
+  ; microsecond
   ; kind = `Time
   }
 
 let timestamp f t =
-  let tm = f t in
+  let tf, ti = modf t in
+  let tm = f ti in
   { year = tm.Unix.tm_year + 1900
   ; month = tm.Unix.tm_mon + 1
   ; day = tm.Unix.tm_mday
   ; hour = tm.Unix.tm_hour
   ; minute = tm.Unix.tm_min
   ; second = tm.Unix.tm_sec
+  ; microsecond = int_of_float (1_000_000. *. tf)
   ; kind = `Timestamp
   }
 
@@ -51,15 +56,17 @@ let date ~year ~month ~day =
   ; hour = 0
   ; minute = 0
   ; second = 0
+  ; microsecond = 0
   ; kind = `Date
   }
 
-let datetime ~year ~month ~day ~hour ~minute ~second =
+let datetime ~year ~month ~day ~hour ~minute ?(microsecond = 0) ~second =
   { year
   ; month
   ; day
   ; hour
   ; minute
   ; second
+  ; microsecond
   ; kind = `Datetime
   }


### PR DESCRIPTION
According to [the MySQL 8.0 documentation][1], `second_part` field represents microseconds, so presumably this is set in stone, but if you prefer, we could keep the `second_part` name in OCaml, use `int64` instead of `int` and expose `SEC_PART_DIGITS`.

I had to put `?microsecond` before `~second` to make it truly optional without fully breaking backwards compatibility.  Alternatively we could add `_us` variants to to all functions taking `~second` arguments.

[1]: https://dev.mysql.com/doc/refman/8.0/en/c-api-prepared-statement-data-structures.html