### PR TITLE
Use cc instead of gcc to get this to compile on FreeBSD

### DIFF
--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 detect () {
-  gcc -o /dev/null detect/detect.c $@ > /dev/null 2>&1
+  cc -o /dev/null detect/detect.c $@ > /dev/null 2>&1
   return $?
 }
 


### PR DESCRIPTION
FreeBSD doesn't have `gcc` so that breaks `./configure`.

`cc` links to GCC on Linux, and to clang on FreeBSD, so it should always work.

With this change, `opam install mariadb` works with these environment variables set:

~~~
CPATH="/usr/local/include/mysql:/usr/local/include/mysql/mysql:/usr/local/include" \
LIBRARY_PATH="/usr/local/lib/mysql:/usr/local/lib" \
opam install mariadb
~~~

We should probably be using `mysql_config`/`mariadb_config` instead, but I guess that's a bit more work to implement.