### PR TITLE
Fix compilation on 32bit platforms

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -48,18 +48,18 @@ module Types (F: Cstubs.Types.TYPE) = struct
   end
 
   module Flags = struct
-    let compress = constant "CLIENT_COMPRESS" int
-    let found_rows = constant "CLIENT_FOUND_ROWS" int
-    let ignore_sigpipe = constant "CLIENT_IGNORE_SIGPIPE" int
-    let ignore_space = constant "CLIENT_IGNORE_SPACE" int
-    let interactive = constant "CLIENT_INTERACTIVE" int
-    let local_files = constant "CLIENT_LOCAL_FILES" int
-    let multi_results = constant "CLIENT_MULTI_RESULTS" int
-    let multi_statements = constant "CLIENT_MULTI_STATEMENTS" int
-    let no_schema = constant "CLIENT_NO_SCHEMA" int
-    let odbc = constant "CLIENT_ODBC" int
-    let ssl = constant "CLIENT_SSL" int
-    let remember_options = constant "CLIENT_REMEMBER_OPTIONS" int
+    let compress = constant "CLIENT_COMPRESS" int32_t
+    let found_rows = constant "CLIENT_FOUND_ROWS" int32_t
+    let ignore_sigpipe = constant "CLIENT_IGNORE_SIGPIPE" int32_t
+    let ignore_space = constant "CLIENT_IGNORE_SPACE" int32_t
+    let interactive = constant "CLIENT_INTERACTIVE" int32_t
+    let local_files = constant "CLIENT_LOCAL_FILES" int32_t
+    let multi_results = constant "CLIENT_MULTI_RESULTS" int32_t
+    let multi_statements = constant "CLIENT_MULTI_STATEMENTS" int32_t
+    let no_schema = constant "CLIENT_NO_SCHEMA" int32_t
+    let odbc = constant "CLIENT_ODBC" int32_t
+    let ssl = constant "CLIENT_SSL" int32_t
+    let remember_options = constant "CLIENT_REMEMBER_OPTIONS" int32_t
   end
 
   module Server_options = struct

--- a/lib/binding_wrappers.ml
+++ b/lib/binding_wrappers.ml
@@ -57,7 +57,7 @@ let mysql_real_connect mysql host user pass db port socket flags =
   let db = char_ptr_opt_buffer_of_string db in
   let port = Unsigned.UInt.of_int port in
   let socket = char_ptr_opt_buffer_of_string socket in
-  let flags = Unsigned.ULong.of_int flags in
+  let flags = Unsigned.ULong.of_int64 (Int64.of_int32 flags) in
   B.mysql_real_connect mysql host user pass db port socket flags
 
 let mysql_commit mysql =
@@ -109,7 +109,7 @@ let mysql_stmt_free_result stmt =
 
 let mysql_real_connect_start mysql host user pass db port socket flags =
   let port = Unsigned.UInt.of_int port in
-  let flags = Unsigned.ULong.of_int flags in
+  let flags = Unsigned.ULong.of_int64 (Int64.of_int32 flags) in
   handle_ret
     (fun ret ->
       B.mysql_real_connect_start ret mysql host user pass db port socket flags)

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -15,7 +15,7 @@ type 'm t =
   ; mutable pass    : char Ctypes.ptr option
   ; mutable db      : char Ctypes.ptr option
   ; socket          : char Ctypes.ptr option
-  ; flags           : int
+  ; flags           : int32
   ; mutable charset : char Ctypes.ptr option
   }
   constraint 'm = [< mode]
@@ -197,7 +197,7 @@ let int_of_flag = function
   | Remember_options -> T.Flags.remember_options
 
 let int_of_flags =
-  List.fold_left (fun acc flag -> acc lor int_of_flag flag) 0
+  List.fold_left (fun acc flag -> Int32.logor acc (int_of_flag flag)) 0l
 
 module Res = struct
   open Ctypes


### PR DESCRIPTION
Would previously fail with:
```
# + /home/opam/.opam/4.11/bin/ocamlfind ocamlc -c -g -annot -bin-annot -I bindings -ccopt -I -ccopt /home/opam/.opam/4.11/lib/ctypes -warn-error +1..45 -package unix -package ctypes.stubs -I lib -I bindings -o lib/ffi_generated_types.cmo lib/ffi_generated_types.ml
# File "lib/ffi_generated_types.ml", line 154, characters 4-15:
# 154 |     -2147483648
#           ^^^^^^^^^^^
# Error: Integer literal exceeds the range of representable integers of type int
```
as `CLIENT_REMEMBER_OPTIONS` is set to `-2147483648` (Int32.min_int) and `int` (being 31bits) is not enough to store this.