### PR TITLE
fix memory leak in free_res

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -273,6 +273,9 @@ module Bindings (F : Cstubs.FOREIGN) = struct
 
   (* Blocking API *)
 
+  let mysql_free_result = foreign "mysql_free_result"
+    (res @-> returning void)
+
   let mysql_real_connect = foreign "mysql_real_connect"
     (mysql @-> ptr_opt char @-> ptr_opt char @->
      ptr_opt char @-> ptr_opt char @-> uint @-> ptr_opt char @-> ulong @->

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -643,6 +643,7 @@ module Make (W : Wait) : S with type 'a future = 'a W.IO.future = struct
       let raw = stmt.Common.Stmt.raw in
       let start = handle_free (B.mysql_stmt_free_result_start raw) in
       let cont s = handle_free (B.mysql_stmt_free_result_cont raw s) in
+      let () = match stmt.Common.Stmt.meta with None -> () | Some { res; _ } -> B.mysql_free_result res in
       nonblocking stmt.Common.Stmt.mariadb (start, cont)
 
     let reset stmt =


### PR DESCRIPTION
https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-result-metadata.html
> When you are done with the metadata result set structure, free it by passing it to mysql_free_result().

### Repro case
`dune` (devkit is used for Memory.reclaim) :
```
(executable
  (name testdb)
  (modes exe)
  (libraries devkit mariadb lwt.unix)
  (modules testdb)
  (preprocess
    (pps lwt_ppx)))
```
`testdb.ml`:
```
open Devkit
module S = Mariadb.Nonblocking.Status

module M = Mariadb.Nonblocking.Make (struct
  module IO = struct
    type 'a future = 'a Lwt.t

    let ( >>= ) = Lwt.bind

    let return = Lwt.return
  end

  let wait mariadb status =
    let fd = Lwt_unix.of_unix_file_descr @@ Mariadb.Nonblocking.fd mariadb in
    assert (S.read status || S.write status || S.timeout status);
    let idle, _ = Lwt.task () in
    let rt = if S.read status then Lwt_unix.wait_read fd else idle in
    let wt = if S.write status then Lwt_unix.wait_write fd else idle in
    let tt =
      match S.timeout status, Mariadb.Nonblocking.timeout mariadb with
      | true, 0 -> Lwt.return ()
      | true, tmout -> Lwt_unix.timeout (float tmout)
      | false, _ -> idle
    in
    Lwt.catch
      (fun () ->
        let%lwt _ = Lwt.nchoose [ rt; wt; tt ] in
        Lwt.return @@ S.create ~read:(Lwt_unix.readable fd) ~write:(Lwt_unix.writable fd) ())
      (function
        | Lwt_unix.Timeout -> Lwt.return @@ S.create ~timeout:true ()
        | e -> Lwt.fail e)
end)

let run () =
  let connect () = M.connect ~host:"127.0.0.1" ~port:3306 ~user:"test" ~pass:"test" ~db:"test" () in
  let or_die x =
    match%lwt x with
    | Error (i, s) ->
      eprintfn "Error %d %s" i s;
      exit 2
    | Ok r -> Lwt.return r
  in
  let%lwt db = connect () |> or_die in
  let query = "SELECT 1" in
  let%lwt () =
    while%lwt true do
      Memory.reclaim ();
      for%lwt i = 0 to 1000 do
        let%lwt stmt = M.prepare db query |> or_die in
        let%lwt () = M.Stmt.close stmt |> or_die in
        Lwt.return_unit
      done
    done
  in
  Memory.reclaim ();
  M.close db

let () = Lwt_main.run @@ run ()
```

before the fix:
```
$ GLIBC_TUNABLES=glibc.malloc.trim_threshold=0 ./testdb.exe 
[2021-03-08T21:15:05.9545] 176132: [memory:info] Memory.reclaim: heap 992KB -> 480KB live 35KB -> 153KB freelist = 1 (0.0008 secs), rss 12.8MB -> 13.3MB (0.0000 secs)
[2021-03-08T21:15:16.3621] 176132: [memory:info] Memory.reclaim: heap = 480KB live 294KB -> 154KB freelist 5018 -> 1 (0.0005 secs), rss 14.8MB -> 15.1MB (0.0000 secs)
[2021-03-08T21:15:27.6536] 176132: [memory:info] Memory.reclaim: heap = 480KB live 227KB -> 154KB freelist 5490 -> 1 (0.0005 secs), rss 15.2MB -> 15.2MB (0.0000 secs)
[2021-03-08T21:15:38.8880] 176132: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 154KB freelist 4977 -> 1 (0.0005 secs), rss 15.3MB -> 15.3MB (0.0000 secs)
[2021-03-08T21:15:49.7611] 176132: [memory:info] Memory.reclaim: heap = 480KB live 227KB -> 154KB freelist 5491 -> 1 (0.0005 secs), rss 15.3MB -> 15.5MB (0.0000 secs)
[2021-03-08T21:16:00.6917] 176132: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 154KB freelist 4977 -> 1 (0.0005 secs), rss 15.6MB -> 15.6MB (0.0000 secs)
[2021-03-08T21:16:11.4848] 176132: [memory:info] Memory.reclaim: heap = 480KB live 227KB -> 154KB freelist 5491 -> 1 (0.0005 secs), rss 15.6MB -> 15.8MB (0.0000 secs)
[2021-03-08T21:16:23.4493] 176132: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 154KB freelist 4977 -> 1 (0.0005 secs), rss 15.8MB -> 15.9MB (0.0000 secs)
[2021-03-08T21:16:33.5215] 176132: [memory:info] Memory.reclaim: heap = 480KB live 227KB -> 154KB freelist 5491 -> 1 (0.0006 secs), rss 15.9MB -> 16.1MB (0.0000 secs)
[2021-03-08T21:16:44.8638] 176132: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 154KB freelist 4977 -> 1 (0.0005 secs), rss 16.1MB -> 16.2MB (0.0000 secs)
[2021-03-08T21:16:56.4649] 176132: [memory:info] Memory.reclaim: heap = 480KB live 227KB -> 154KB freelist 5491 -> 1 (0.0007 secs), rss 16.2MB -> 16.3MB (0.0000 secs)
[2021-03-08T21:17:08.5156] 176132: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 154KB freelist 4977 -> 1 (0.0005 secs), rss 16.4MB -> 16.4MB (0.0000 secs)
[2021-03-08T21:17:18.9161] 176132: [memory:info] Memory.reclaim: heap = 480KB live 227KB -> 154KB freelist 5491 -> 1 (0.0006 secs), rss 16.4MB -> 16.6MB (0.0000 secs)
```
(important number is the last bytes measurement, which is resident set size after malloc_release)

after the fix:
```
$ GLIBC_TUNABLES=glibc.malloc.trim_threshold=0 ./testdb.exe 
[2021-03-08T21:19:15.3249] 179674: [memory:info] Memory.reclaim: heap 992KB -> 480KB live 35KB -> 153KB freelist = 1 (0.0008 secs), rss 12.7MB -> 13.2MB (0.0000 secs)
[2021-03-08T21:19:24.8679] 179674: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 155KB freelist 5020 -> 1 (0.0005 secs), rss 14.8MB -> 14.9MB (0.0000 secs)
[2021-03-08T21:19:34.7832] 179674: [memory:info] Memory.reclaim: heap = 480KB live 228KB -> 155KB freelist 5491 -> 1 (0.0006 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:19:44.7059] 179674: [memory:info] Memory.reclaim: heap = 480KB live 296KB -> 155KB freelist 4967 -> 1 (0.0006 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:19:54.4285] 179674: [memory:info] Memory.reclaim: heap = 480KB live 225KB -> 155KB freelist 5466 -> 1 (0.0006 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:20:04.7968] 179674: [memory:info] Memory.reclaim: heap = 480KB live 296KB -> 155KB freelist 4967 -> 1 (0.0005 secs), rss 14.9MB -> 14.9MB (0.0000 secs)
[2021-03-08T21:20:14.6548] 179674: [memory:info] Memory.reclaim: heap = 480KB live 228KB -> 155KB freelist 5491 -> 1 (0.0005 secs), rss 14.9MB -> 14.9MB (0.0000 secs)
[2021-03-08T21:20:24.4880] 179674: [memory:info] Memory.reclaim: heap = 480KB live 295KB -> 155KB freelist 4978 -> 1 (0.0005 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:20:35.3080] 179674: [memory:info] Memory.reclaim: heap = 480KB live 225KB -> 155KB freelist 5466 -> 1 (0.0007 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:20:45.6080] 179674: [memory:info] Memory.reclaim: heap = 480KB live 296KB -> 155KB freelist 4967 -> 1 (0.0005 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:20:55.9028] 179674: [memory:info] Memory.reclaim: heap = 480KB live 225KB -> 155KB freelist 5466 -> 1 (0.0007 secs), rss = 14.9MB (0.0000 secs)
[2021-03-08T21:21:06.4356] 179674: [memory:info] Memory.reclaim: heap = 480KB live 296KB -> 155KB freelist 4967 -> 1 (0.0005 secs), rss = 14.9MB (0.0000 secs)
```