### PR TITLE
Retrieve statement metadata after statement execution

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -273,6 +273,9 @@ module Bindings (F : Cstubs.FOREIGN) = struct
 
   (* Blocking API *)
 
+  let mysql_free_result = foreign "mysql_free_result"
+    (res @-> returning void)
+
   let mysql_real_connect = foreign "mysql_real_connect"
     (mysql @-> ptr_opt char @-> ptr_opt char @->
      ptr_opt char @-> ptr_opt char @-> uint @-> ptr_opt char @-> ulong @->

--- a/lib/blocking.ml
+++ b/lib/blocking.ml
@@ -143,9 +143,7 @@ let rollback mariadb =
 let prepare mariadb query =
   let build_stmt raw =
     if B.mysql_stmt_prepare raw query then
-      match Common.Stmt.init mariadb raw with
-      | Some stmt -> Ok stmt
-      | None -> Error (Common.error mariadb)
+      Ok (Common.Stmt.init mariadb raw)
     else
       Error (Common.error mariadb) in
   match Common.stmt_init mariadb with

--- a/lib/blocking.ml
+++ b/lib/blocking.ml
@@ -190,6 +190,7 @@ module Stmt = struct
     end
 
   let reset stmt =
+    Common.Stmt.free_meta stmt;
     let raw = stmt.Common.Stmt.raw in
     if B.mysql_stmt_free_result raw && B.mysql_stmt_reset raw then
       Ok ()
@@ -197,6 +198,7 @@ module Stmt = struct
       Error (Common.Stmt.error stmt)
 
   let close stmt =
+    Common.Stmt.free_meta stmt;
     let raw = stmt.Common.Stmt.raw in
     if B.mysql_stmt_free_result raw && B.mysql_stmt_close raw then
       Ok ()

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -178,9 +178,7 @@ let rollback mariadb =
   (rollback_start mariadb, rollback_cont mariadb)
 
 let build_stmt mariadb raw =
-  match Common.Stmt.init mariadb raw with
-  | Some stmt -> `Ok stmt
-  | None -> `Error (Common.error mariadb)
+  `Ok (Common.Stmt.init mariadb raw)
 
 type prep_stmt =
   { raw   : B.stmt

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -635,6 +635,7 @@ module Make (W : Wait) : S with type 'a future = 'a W.IO.future = struct
       | `Error e -> return (Error e)
 
     let free_res stmt =
+      Common.Stmt.free_meta stmt;
       let handle_free = function
         | 0, '\000' -> `Ok ()
         | 0, _ -> `Error (Common.Stmt.error stmt)


### PR DESCRIPTION
Currently, we get the result metadata immediately after preparing the statement. But this metadata is not guaranteed to match the actual result. And in case of `INSERT ... RETURNING`, it does not.

MySQL documentation mentions (emphasis mine):

> If you call mysql_stmt_result_metadata() after mysql_stmt_prepare() but before mysql_stmt_execute(), the column types in the metadata are as determined by the optimizer. If you call mysql_stmt_result_metadata() after mysql_stmt_execute(), the column types in the metadata are as actually present in the result set. **In most cases, these should be the same.**

And most ≠ all.

So this PR reloads the result metadata after each statement execution.

This fixes #33, and also ensures correctness of the row structure if table or view definitions change after statement preparation. Also see that issue for reproduction steps.