### PR TITLE
bash -> console for shell sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ the C connector library version 2.1.0 or greater (but version 3.0.0 or greater
 is recommended). If your distribution has these already packaged those versions,
 simply install either package. For example, on Debian or Ubuntu, run
 
-```sh
+```console
 # apt-get install libmariadbclient-dev
 ```
 
 to use the client library, or
 
-```sh
+```console
 # apt-get install libmariadb-dev
 ```
 
@@ -43,13 +43,13 @@ the client library will be available.
 
 To install OCaml-MariaDB via [OPAM](https://opam.ocaml.org/) simply type
 
-```sh
+```console
 $ opam install mariadb
 ```
 
 To install it manually, type
 
-```sh
+```console
 $ ./configure
 $ ocaml setup.ml -build
 $ ocaml setup.ml -install
@@ -127,7 +127,6 @@ module type Wait = sig
   val wait : t -> Mariadb.Nonblocking.Status.t
           -> Mariadb.Nonblocking.Status.t IO.future
 end
-
 ```
 
 The `wait` function receives a *status* parameter that specifies which socket


### PR DESCRIPTION
These blocks were not shell scripts but shell *sessions*, and as such moved the syntax over