### PR TITLE
Fix binding negative ints

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -326,6 +326,9 @@ module Bindings (F : Cstubs.FOREIGN) = struct
   let mysql_stmt_free_result = foreign "mysql_stmt_free_result"
     (stmt @-> returning my_bool)
 
+  let mysql_real_query = foreign "mysql_real_query"
+    (mysql @-> ptr char @-> ulong @-> returning int)
+
   (* Nonblocking API *)
 
   let mysql_close_start = foreign "mysql_close_start"
@@ -447,4 +450,10 @@ module Bindings (F : Cstubs.FOREIGN) = struct
 
   let mysql_stmt_next_result_cont = foreign "mysql_stmt_next_result_cont"
     (ptr int @-> stmt @-> int @-> returning int)
+
+  let mysql_real_query_start = foreign "mysql_real_query_start"
+    (ptr int @-> mysql @-> ptr char @-> ulong @-> returning int)
+
+  let mysql_real_query_cont = foreign "mysql_real_query_cont"
+    (ptr int @-> mysql @-> int @-> returning int)
 end

--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -273,6 +273,9 @@ module Bindings (F : Cstubs.FOREIGN) = struct
 
   (* Blocking API *)
 
+  let mysql_free_result = foreign "mysql_free_result"
+    (res @-> returning void)
+
   let mysql_real_connect = foreign "mysql_real_connect"
     (mysql @-> ptr_opt char @-> ptr_opt char @->
      ptr_opt char @-> ptr_opt char @-> uint @-> ptr_opt char @-> ulong @->

--- a/lib/bind.ml
+++ b/lib/bind.ml
@@ -116,10 +116,10 @@ let short ?(unsigned = false) b param ~at =
     ~at
 
 let int ?(unsigned = false) b param ~at =
-  let p = allocate int param in
+  let p = allocate llong (Signed.LLong.of_int param) in
   bind b
-    ~buffer:(coerce (ptr int) (ptr void) p)
-    ~size:(sizeof int)
+    ~buffer:(coerce (ptr llong) (ptr void) p)
+    ~size:(sizeof llong)
     ~mysql_type:T.Type.long_long
     ~unsigned:(if unsigned then yes else no)
     ~at

--- a/lib/binding_wrappers.ml
+++ b/lib/binding_wrappers.ml
@@ -105,6 +105,11 @@ let mysql_stmt_store_result stmt =
 let mysql_stmt_free_result stmt =
   B.mysql_stmt_free_result stmt = '\000'
 
+let mysql_real_query mysql query =
+  let len = Unsigned.ULong.of_int (String.length query) in
+  let query = char_ptr_buffer_of_string query in
+  B.mysql_real_query mysql query len = 0
+
 (* Nonblocking API *)
 
 let mysql_real_connect_start mysql host user pass db port socket flags =
@@ -220,3 +225,11 @@ let mysql_stmt_next_result_start stmt =
 
 let mysql_stmt_next_result_cont stmt status =
   handle_int (fun err -> B.mysql_stmt_next_result_cont err stmt status)
+
+let mysql_real_query_start mysql query =
+  let len = Unsigned.ULong.of_int (String.length query) in
+  let query = char_ptr_buffer_of_string query in
+  handle_int (fun err -> B.mysql_real_query_start err mysql query len)
+
+let mysql_real_query_cont mysql status =
+  handle_int (fun err -> B.mysql_real_query_cont err mysql status)

--- a/lib/blocking.ml
+++ b/lib/blocking.ml
@@ -143,9 +143,7 @@ let rollback mariadb =
 let prepare mariadb query =
   let build_stmt raw =
     if B.mysql_stmt_prepare raw query then
-      match Common.Stmt.init mariadb raw with
-      | Some stmt -> Ok stmt
-      | None -> Error (Common.error mariadb)
+      Ok (Common.Stmt.init mariadb raw)
     else
       Error (Common.error mariadb) in
   match Common.stmt_init mariadb with
@@ -192,6 +190,7 @@ module Stmt = struct
     end
 
   let reset stmt =
+    Common.Stmt.free_meta stmt;
     let raw = stmt.Common.Stmt.raw in
     if B.mysql_stmt_free_result raw && B.mysql_stmt_reset raw then
       Ok ()
@@ -199,6 +198,7 @@ module Stmt = struct
       Error (Common.Stmt.error stmt)
 
   let close stmt =
+    Common.Stmt.free_meta stmt;
     let raw = stmt.Common.Stmt.raw in
     if B.mysql_stmt_free_result raw && B.mysql_stmt_close raw then
       Ok ()

--- a/lib/blocking.ml
+++ b/lib/blocking.ml
@@ -150,6 +150,9 @@ let prepare mariadb query =
   | Some raw -> build_stmt raw
   | None -> Error (2008, "out of memory")
 
+let start_txn mariadb =
+  wrap_unit mariadb (B.mysql_real_query mariadb.Common.raw "START TRANSACTION")
+
 module Res = struct
   type t = [`Blocking] Common.Res.t
 

--- a/lib/mariadb.ml
+++ b/lib/mariadb.ml
@@ -159,6 +159,7 @@ module type S = sig
   val set_server_option : t -> server_option -> unit result
   val ping : t -> unit result
   val autocommit : t -> bool -> unit result
+  val start_txn : t -> unit result
   val commit : t -> unit result
   val rollback : t -> unit result
   val prepare : t -> string -> Stmt.t result

--- a/lib/mariadb.mli
+++ b/lib/mariadb.mli
@@ -264,6 +264,8 @@ module type S = sig
   val autocommit : t -> bool -> unit result
     (** Sets autocommit mode on or off. *)
 
+  val start_txn : t -> unit result
+
   val commit : t -> unit result
     (** Commits the current transaction. *)
 
@@ -510,6 +512,7 @@ module Nonblocking : sig
     val set_server_option : t -> server_option -> unit result future
     val ping : t -> unit result future
     val autocommit : t -> bool -> unit result future
+    val start_txn : t -> unit result future
     val commit : t -> unit result future
     val rollback : t -> unit result future
     val prepare : t -> string -> Stmt.t result future

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -178,9 +178,7 @@ let rollback mariadb =
   (rollback_start mariadb, rollback_cont mariadb)
 
 let build_stmt mariadb raw =
-  match Common.Stmt.init mariadb raw with
-  | Some stmt -> `Ok stmt
-  | None -> `Error (Common.error mariadb)
+  `Ok (Common.Stmt.init mariadb raw)
 
 type prep_stmt =
   { raw   : B.stmt
@@ -637,6 +635,7 @@ module Make (W : Wait) : S with type 'a future = 'a W.IO.future = struct
       | `Error e -> return (Error e)
 
     let free_res stmt =
+      Common.Stmt.free_meta stmt;
       let handle_free = function
         | 0, '\000' -> `Ok ()
         | 0, _ -> `Error (Common.Stmt.error stmt)

--- a/lib/nonblocking.ml
+++ b/lib/nonblocking.ml
@@ -177,6 +177,15 @@ let rollback_cont mariadb status =
 let rollback mariadb =
   (rollback_start mariadb, rollback_cont mariadb)
 
+let start_txn_start mariadb =
+  handle_int mariadb (B.mysql_real_query_start mariadb.Common.raw "START TRANSACTION")
+
+let start_txn_cont mariadb status =
+  handle_int mariadb (B.mysql_real_query_cont mariadb.Common.raw status)
+
+let start_txn mariadb =
+  (start_txn_start mariadb, start_txn_cont mariadb)
+
 let build_stmt mariadb raw =
   `Ok (Common.Stmt.init mariadb raw)
 
@@ -516,6 +525,7 @@ module type S = sig
   val set_server_option : t -> server_option -> unit result future
   val ping : t -> unit result future
   val autocommit : t -> bool -> unit result future
+  val start_txn : t -> unit result future
   val commit : t -> unit result future
   val rollback : t -> unit result future
   val prepare : t -> string -> Stmt.t result future
@@ -703,6 +713,8 @@ module Make (W : Wait) : S with type 'a future = 'a W.IO.future = struct
   let ping m = nonblocking m (ping m)
 
   let autocommit m b = nonblocking m (autocommit m b)
+
+  let start_txn m = nonblocking m (start_txn m)
 
   let commit m = nonblocking m (commit m)
 


### PR DESCRIPTION
Fixes #31.
There is also a PR #48 which narrows down the integer to 32 bits instead, which is worse IMO because it will break working with BIGINT fields.